### PR TITLE
Add ability to request reviewers when creating a PR

### DIFF
--- a/lazy_github/lib/config.py
+++ b/lazy_github/lib/config.py
@@ -17,6 +17,19 @@ ISSUE_STATE_FILTER = Literal["all"] | Literal["open"] | Literal["closed"]
 ISSUE_OWNER_FILTER = Literal["mine"] | Literal["all"]
 
 
+def _serialize_string_list(cls, string_list: str | list[str]) -> list[str]:
+    if isinstance(string_list, list):
+        return string_list
+    elif isinstance(string_list, str):
+        return list(set(s.strip() for s in string_list.split(",") if s.strip()))
+
+
+def _parse_string_list(cls, v) -> list[str]:
+    if isinstance(v, str):
+        return list(set(s.strip() for s in v.split(",") if s.strip()))
+    return v
+
+
 class AppearanceSettings(BaseModel):
     """Settings focused on altering the appearance of LazyGithub, including hiding or showing different sections."""
 
@@ -69,17 +82,12 @@ class RepositorySettings(BaseModel):
     @field_serializer("additional_repos_to_track", "favorites")
     @classmethod
     def serialize_string_list(cls, string_list: str | list[str]) -> list[str]:
-        if isinstance(string_list, list):
-            return string_list
-        elif isinstance(string_list, str):
-            return list(set(s.strip() for s in string_list.split(",") if s.strip()))
+        return _serialize_string_list(cls, string_list)
 
     @field_validator("additional_repos_to_track", "favorites", mode="before")
     @classmethod
     def parse_string_list(cls, v) -> list[str]:
-        if isinstance(v, str):
-            return list(set(s.strip() for s in v.split(",") if s.strip()))
-        return v
+        return _parse_string_list(cls, v)
 
     additional_repos_to_track: list[str] = []
     """Records repositories the user is not an owner of but would like to show in the UI and keep track of"""
@@ -99,6 +107,16 @@ class MergeMethod(StrEnum):
 class PullRequestSettings(BaseModel):
     """Changes how pull requests are retrieved from the Github API"""
 
+    @field_serializer("additional_suggested_pr_reviewers")
+    @classmethod
+    def serialize_string_list(cls, string_list: str | list[str]) -> list[str]:
+        return _serialize_string_list(cls, string_list)
+
+    @field_validator("additional_suggested_pr_reviewers", mode="before")
+    @classmethod
+    def parse_string_list(cls, v) -> list[str]:
+        return _parse_string_list(cls, v)
+
     state_filter: IssueStateFilter = IssueStateFilter.ALL
     """Controls if we're only listing pull requests in a particular state (ex: Open)"""
 
@@ -107,6 +125,9 @@ class PullRequestSettings(BaseModel):
 
     preferred_merge_method: MergeMethod = MergeMethod.SQUASH
     """How we will request that Github merge pull requests"""
+
+    additional_suggested_pr_reviewers: list[str] = []
+    """An list of additional usernames to suggest as reviewers on PRs"""
 
 
 class IssueSettings(BaseModel):

--- a/lazy_github/lib/github/backends/cli.py
+++ b/lazy_github/lib/github/backends/cli.py
@@ -112,7 +112,7 @@ def build_command(
     method: str = "GET",
     headers: Headers | None = None,
     query_params: QueryParams | None = None,
-    body: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
 ) -> list[str]:
     command = ["api", "-i", "-X", method]
 
@@ -150,7 +150,7 @@ class GithubCliBackend(GithubApiBackend):
         self,
         url: str,
         headers: Headers | None = None,
-        json: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> Any:
         command = build_command(url, headers=headers, body=json, method="POST")
         return await run_gh_cli_command(command)

--- a/lazy_github/lib/github/backends/hishel.py
+++ b/lazy_github/lib/github/backends/hishel.py
@@ -61,7 +61,7 @@ class HishelGithubApiBackend(GithubApiBackend):
         self,
         url: str,
         headers: Headers | None = None,
-        json: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> HishelApiResponse:
         response = await self.api_client.post(url, headers=headers, json=json)
         return HishelApiResponse(response)

--- a/lazy_github/lib/github/backends/protocol.py
+++ b/lazy_github/lib/github/backends/protocol.py
@@ -41,7 +41,7 @@ class GithubApiBackend(Protocol):
         self,
         url: str,
         headers: Headers | None = None,
-        json: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> GithubApiResponse: ...
 
     async def patch(

--- a/lazy_github/lib/github/client.py
+++ b/lazy_github/lib/github/client.py
@@ -37,7 +37,7 @@ class GithubClient(GithubApiBackend):
     async def get(self, url: str, headers: Headers | None = None, params: QueryParams | None = None) -> Any:
         return await self.backend.get(url, headers, params)
 
-    async def post(self, url: str, headers: Headers | None = None, json: dict[str, str] | None = None) -> Any:
+    async def post(self, url: str, headers: Headers | None = None, json: dict[str, Any] | None = None) -> Any:
         return await self.backend.post(url, headers, json)
 
     async def patch(self, url: str, headers: Headers | None = None, json: dict[str, str] | None = None) -> Any:

--- a/lazy_github/lib/github/pull_requests.py
+++ b/lazy_github/lib/github/pull_requests.py
@@ -148,3 +148,10 @@ def reconstruct_review_conversation_hierarchy(reviews: list[Review]) -> dict[int
             comment_nodes_by_review_id[in_reply_to_id].children.append(review_node)
 
     return {r.comment.id: r for r in comment_nodes_by_review_id.values() if r.comment.in_reply_to_id is None}
+
+
+async def request_reviews(pr: FullPullRequest, reviewers: list[str]) -> bool:
+    body = {"reviewers": reviewers}
+    url = f"/repos/{pr.repo.full_name}/pulls/{pr.number}"
+    response = await LazyGithubContext.client.post(url, json=body)
+    return response.is_success()

--- a/lazy_github/lib/github/repositories.py
+++ b/lazy_github/lib/github/repositories.py
@@ -64,3 +64,12 @@ async def get_repository_by_name(full_name: str) -> Repository | None:
         return Repository(**response.json())
     except GithubApiRequestFailed:
         return None
+
+
+async def get_collaborators(full_name: str) -> list[str]:
+    """Returns collaborators for the specified repo"""
+    collaborators = []
+    response = await LazyGithubContext.client.get(f"/repos/{full_name}/collaborators")
+    if response.is_success():
+        collaborators.extend(u["login"] for u in response.json())
+    return collaborators

--- a/lazy_github/lib/github/users.py
+++ b/lazy_github/lib/github/users.py
@@ -1,0 +1,7 @@
+from lazy_github.lib.context import LazyGithubContext
+from lazy_github.models.github import User
+
+
+async def get_user_by_username(username: str) -> User | None:
+    response = await LazyGithubContext.client.get(f"/users/{username}")
+    return User(**response.json()) if response.is_success() else None

--- a/lazy_github/ui/screens/new_pull_request.py
+++ b/lazy_github/ui/screens/new_pull_request.py
@@ -222,6 +222,9 @@ class NewPullRequestContainer(VerticalScroll):
         yield ReviewerSelectionContainer()
         yield NewPullRequestButtons()
 
+    def on_mount(self) -> None:
+        self.query_one("#pr_title", Input).focus()
+
     @on(Button.Pressed, "#cancel_new_pr")
     def cancel_pull_request(self, _: Button.Pressed):
         self.app.pop_screen()

--- a/lazy_github/ui/screens/new_pull_request.py
+++ b/lazy_github/ui/screens/new_pull_request.py
@@ -263,8 +263,10 @@ class NewPullRequestContainer(VerticalScroll):
             return
 
         reviewer_container = self.query_one(ReviewerSelectionContainer)
-        if reviewer_container.reviewers:
-            await request_reviews(created_pr, list(reviewer_container.reviewers))
+        reviewers = list(reviewer_container.reviewers)
+        if reviewers:
+            lg.info(f"Requesting PR reviews from: {', '.join(reviewers)}")
+            await request_reviews(created_pr, reviewers)
 
         self.notify("Successfully created PR!")
         self.post_message(PullRequestCreated(created_pr))

--- a/lazy_github/ui/screens/new_pull_request.py
+++ b/lazy_github/ui/screens/new_pull_request.py
@@ -3,11 +3,13 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Markdown, Rule, SelectionList, Switch, TextArea
+from textual.widgets.selection_list import Selection
 
 from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.context import LazyGithubContext
 from lazy_github.lib.github.branches import list_branches
 from lazy_github.lib.github.pull_requests import create_pull_request
+from lazy_github.lib.github.repositories import get_collaborators
 from lazy_github.lib.github.users import get_user_by_username
 from lazy_github.lib.logging import lg
 from lazy_github.lib.messages import BranchesLoaded, PullRequestCreated
@@ -124,7 +126,9 @@ class ReviewerSelectionContainer(Vertical):
         super().__init__()
         self.reviewers: set[str] = set()
         self.new_reviewer = Input(id="new_reviewer", placeholder="Reviewer to add")
-        self.current_reviewers_label = Label("Current Reviewers", id="current_reviewers_label")
+        self.current_reviewers_label = Label(
+            "Current Reviewers - Click/Select them to remove", id="current_reviewers_label"
+        )
         self.current_reviewers_label.display = False
         self.reviewers_selection_list = SelectionList(id="current_reviewers")
         self.reviewers_selection_list.display = False
@@ -132,19 +136,34 @@ class ReviewerSelectionContainer(Vertical):
     def compose(self) -> ComposeResult:
         yield Label("[bold]Reviewers[/bold]")
         yield self.new_reviewer
+        yield self.current_reviewers_label
         yield self.reviewers_selection_list
-        return super().compose()
+
+    async def on_mount(self) -> None:
+        reviewer_suggester = suggester.SuggestFromList(
+            LazyGithubContext.config.pull_requests.additional_suggested_pr_reviewers
+        )
+        self.new_reviewer.suggester = reviewer_suggester
+        self._fetch_collaborators()
+
+    @work
+    async def _fetch_collaborators(self) -> None:
+        if LazyGithubContext.current_repo:
+            collaborators = await get_collaborators(LazyGithubContext.current_repo.full_name)
+            collaborators.extend(LazyGithubContext.config.pull_requests.additional_suggested_pr_reviewers)
+            reviewer_suggester = suggester.SuggestFromList(collaborators)
+            self.new_reviewer.suggester = reviewer_suggester
 
     @work
     async def _validate_new_reviewer(self, reviewer: str) -> None:
         if reviewer in self.reviewers:
             self.notify("Already a reviewer!", severity="error")
         elif not await get_user_by_username(reviewer):
-            self.notify(f"Could not find user {reviewer} - are you sure they exist?", severity="error")
+            self.notify(f"Could not find user [yellow]{reviewer}[/yellow] - are you sure they exist?", severity="error")
         else:
             lg.info(f"Adding {self.new_reviewer.value} to PR reviewer list")
             self.reviewers.add(reviewer)
-            self.reviewers_selection_list.add_option((reviewer, reviewer, True))
+            self.reviewers_selection_list.add_option(Selection(reviewer, reviewer, id=reviewer, initial_state=True))
             self.new_reviewer.value = ""
             self.current_reviewers_label.display = True
             self.reviewers_selection_list.display = True
@@ -155,8 +174,16 @@ class ReviewerSelectionContainer(Vertical):
 
     @on(SelectionList.SelectionToggled)
     async def handle_reviewer_deselected(self, toggled: SelectionList.SelectionToggled) -> None:
-        self.notify(f"Toggled {toggled}")
-        pass
+        reviewer_to_remove = toggled.selection.value
+        self.notify(f"Removing {reviewer_to_remove}")
+        self.reviewers.remove(reviewer_to_remove)
+        self.reviewers_selection_list.remove_option(reviewer_to_remove)
+
+        # If we've removed all of the reviewers, hide the display
+        if not self.reviewers:
+            self.new_reviewer.focus()
+            self.current_reviewers_label.display = False
+            self.reviewers_selection_list.display = False
 
 
 class NewPullRequestContainer(VerticalScroll):

--- a/lazy_github/ui/widgets/info.py
+++ b/lazy_github/ui/widgets/info.py
@@ -17,8 +17,7 @@ retrieved and displayed below it.
 ## Pull Requests
 
 You can interact with a PR by viewing its details, viewing the PR diff, and participating in any active conversations
-happening on the PR. You can also create a new PR for the currently selected repo. It doesn't currently support merging
-a PR from within LazyGithub.
+happening on the PR. You can also create a new PR for the currently selected repo.
 
 ## Issues
 
@@ -28,7 +27,8 @@ issue, and by editing the issue itself. This means that you can close an issue f
 ## Actions
 
 Github action and workflow support is pretty limited. It currently only supports listing the workflows and the most
-recent runs across all actions on the currently selected repo.
+recent runs across all actions on the currently selected repo, as well as kicking off a workflow that supports manual
+triggers.
 """.strip()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "lazy-github"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This adds a new section to the PR creation modal that allows you to select reviewers. It'll try to pull the list of collaborators on your current repo to auto-populate suggestions, but there is also a new configuration option that will let you set "additional reviewers" that will always be suggested. These are useful if you have a common set of folks that you work with and want to use reference them as reviewers :)