### PR TITLE
Add custom nix flake

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,12 @@
     "allow": [
       "Bash(find:*)",
       "Bash(ls:*)",
-      "Bash(./start.sh:*)"
+      "Bash(./start.sh:*)",
+      "Bash(nix flake check:*)",
+      "Bash(nix-prefetch-url:*)",
+      "Bash(nix-prefetch-github:*)",
+      "Bash(nix search:*)",
+      "Bash(nix build:*)"
     ],
     "deny": []
   }

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# nix stuff
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,28 +6,44 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        
+
         # Use Python with tests disabled globally
         python = pkgs.python311.override {
           packageOverrides = final: prev: {
-            buildPythonPackage = args: prev.buildPythonPackage (args // { 
-              doCheck = false;
-            });
-            buildPythonApplication = args: prev.buildPythonApplication (args // { 
-              doCheck = false;
-            });
+            buildPythonPackage =
+              args:
+              prev.buildPythonPackage (
+                args
+                // {
+                  doCheck = false;
+                }
+              );
+            buildPythonApplication =
+              args:
+              prev.buildPythonApplication (
+                args
+                // {
+                  doCheck = false;
+                }
+              );
           };
         };
-        
+
       in
       {
         packages.default = python.pkgs.buildPythonApplication {
           pname = "lazy-github";
-          version = "0.1.0";
+          version = builtins.replaceStrings ["\n" "\"" " " "VERSION" "="] ["" "" "" "" ""] (builtins.readFile ./lazy_github/version.py);
           format = "pyproject";
 
           src = ./.;
@@ -56,11 +72,13 @@
 
         # Development shell
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
+          buildInputs = [
             python
             python.pkgs.pip
             python.pkgs.uv
           ];
         };
-      });
+      }
+    );
 }
+

--- a/flake.nix
+++ b/flake.nix
@@ -10,26 +10,19 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        python = pkgs.python311;
         
-        textual-fspicker = python.pkgs.buildPythonPackage rec {
-          pname = "textual-fspicker";
-          version = "0.4.1";
-          format = "pyproject";
-
-          src = pkgs.fetchPypi {
-            inherit pname version;
-            sha256 = "sha256-1iaak97il3aydz3li5ggy3njj2pmxf8hvcfvjpl4qjw6q54i26l6=";
+        # Use Python with tests disabled globally
+        python = pkgs.python311.override {
+          packageOverrides = final: prev: {
+            buildPythonPackage = args: prev.buildPythonPackage (args // { 
+              doCheck = false;
+            });
+            buildPythonApplication = args: prev.buildPythonApplication (args // { 
+              doCheck = false;
+            });
           };
-
-          nativeBuildInputs = with python.pkgs; [
-            hatchling
-          ];
-
-          propagatedBuildInputs = with python.pkgs; [
-            textual
-          ];
         };
+        
       in
       {
         packages.default = python.pkgs.buildPythonApplication {
@@ -49,8 +42,9 @@
             pydantic
             textual
             click
-            textual-fspicker
           ];
+
+          doCheck = false;
 
           meta = with pkgs.lib; {
             description = "A terminal UI for interacting with Github";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "A terminal UI for interacting with Github";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python311;
+        
+        textual-fspicker = python.pkgs.buildPythonPackage rec {
+          pname = "textual-fspicker";
+          version = "0.4.1";
+          format = "pyproject";
+
+          src = pkgs.fetchPypi {
+            inherit pname version;
+            sha256 = "sha256-1iaak97il3aydz3li5ggy3njj2pmxf8hvcfvjpl4qjw6q54i26l6=";
+          };
+
+          nativeBuildInputs = with python.pkgs; [
+            hatchling
+          ];
+
+          propagatedBuildInputs = with python.pkgs; [
+            textual
+          ];
+        };
+      in
+      {
+        packages.default = python.pkgs.buildPythonApplication {
+          pname = "lazy-github";
+          version = "0.1.0";
+          format = "pyproject";
+
+          src = ./.;
+
+          nativeBuildInputs = with python.pkgs; [
+            hatchling
+          ];
+
+          propagatedBuildInputs = with python.pkgs; [
+            httpx
+            hishel
+            pydantic
+            textual
+            click
+            textual-fspicker
+          ];
+
+          meta = with pkgs.lib; {
+            description = "A terminal UI for interacting with Github";
+            homepage = "https://github.com/gizmo385/gh-lazy";
+            license = licenses.mit;
+            maintainers = [ ];
+          };
+        };
+
+        # Development shell
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            python
+            python.pkgs.pip
+            python.pkgs.uv
+          ];
+        };
+      });
+}

--- a/lazy_github/cli.py
+++ b/lazy_github/cli.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 
 import click
@@ -14,6 +15,10 @@ _CLI_CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 @click.pass_context
 def cli(ctx: click.Context) -> None:
     """A Terminal UI for interacting with Github"""
+    # Set LAZY_GITHUB_ORIGINAL_PWD if not already set (fixes repo detection when installed via flake)
+    if "LAZY_GITHUB_ORIGINAL_PWD" not in os.environ:
+        os.environ["LAZY_GITHUB_ORIGINAL_PWD"] = os.getcwd()
+    
     if ctx.invoked_subcommand is None:
         ctx.invoke(run)
 

--- a/lazy_github/ui/screens/settings.py
+++ b/lazy_github/ui/screens/settings.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
-from textual import on, work
+from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, ScrollableContainer, Vertical

--- a/lazy_github/ui/screens/settings.py
+++ b/lazy_github/ui/screens/settings.py
@@ -16,8 +16,6 @@ from textual.theme import BUILTIN_THEMES, Theme
 from textual.validation import ValidationResult, Validator
 from textual.widget import Widget
 from textual.widgets import Button, Collapsible, Input, Label, Markdown, RichLog, Rule, Select, Static, Switch
-from textual_fspicker import FileOpen
-from textual_fspicker.path_filters import Filters
 
 from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.context import LazyGithubContext
@@ -41,59 +39,12 @@ class ListOfStringValidator(Validator):
         return self.success()
 
 
-class FileSelector(Vertical):
-    DEFAULT_CSS = """
-    FileSelector {
-        height: 10;
-    }
-
-    Input {
-        width: 70;
-    }
-    """
+class PathInput(Input):
+    """Simple input field for file paths"""
 
     def __init__(self, field_name: str, field: FieldInfo, selected_file: Path | None) -> None:
-        super().__init__()
-        self.field_name = field_name
-        self.field = field
-        self.selected_file: Path | None = selected_file
-
-        self.input_id = _id_for_field_input(self.field_name)
-        self.submit_button = Button("Select File")
-        self.remove_button = Button("Remove File")
-        self.remove_button.visible = self.selected_file is not None
-        self.remove_button.display = self.selected_file is not None
-
-    def compose(self) -> ComposeResult:
-        current_filename = str(self.selected_file) if self.selected_file else ""
-        yield Input(current_filename, disabled=True, id=self.input_id, placeholder="No file selected")
-        yield self.submit_button
-        yield self.remove_button
-
-    @work
-    async def select_file(self) -> None:
-        markdown_filter = Filters(("Markdown", lambda p: p.suffix.lower() == ".md"))
-        file_picker = FileOpen(
-            open_button="Select",
-            default_file=self.selected_file,
-            must_exist=True,
-            filters=markdown_filter,
-        )
-        if new_selected_file := await self.app.push_screen_wait(file_picker):
-            self.selected_file = new_selected_file
-            self.query_one(f"#{self.input_id}", Input).value = str(new_selected_file)
-
-    @on(Button.Pressed)
-    async def handle_select_file_pressed(self, press: Button.Pressed) -> None:
-        if press.button is self.submit_button:
-            self.select_file()
-            self.remove_button.visible = True
-            self.remove_button.display = True
-        elif press.button is self.remove_button:
-            self.query_one(f"#{self.input_id}", Input).value = ""
-            self.selected_file = None
-            self.remove_button.visible = False
-            self.remove_button.display = False
+        current_filename = str(selected_file) if selected_file else ""
+        super().__init__(value=current_filename, id=_id_for_field_input(field_name), placeholder="Enter file path...")
 
 
 class FieldSetting(Container):
@@ -126,7 +77,7 @@ class FieldSetting(Container):
         elif self.field.annotation == list[str]:
             return Input(value=str(", ".join(self.value)), id=id, validators=[ListOfStringValidator()])
         elif self.field.annotation == Optional[Path]:
-            return FileSelector(self.field_name, self.field, self.value)
+            return PathInput(self.field_name, self.field, self.value)
         else:
             # If no other input mechanism fits, then we'll fallback to just a raw string input field
             return Input(value=str(self.value), id=id)
@@ -342,8 +293,8 @@ class SettingsContainer(Container):
 
                     # We want to handle paths specially
                     new_value = updated_value_input.value
-                    if field_info.annotation == Path | None:
-                        new_value = Path(str(new_value)) if new_value else None
+                    if field_info.annotation == Optional[Path]:
+                        new_value = Path(str(new_value).strip()) if new_value and str(new_value).strip() else None
 
                     setattr(model, field_name, new_value)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
 	"pydantic<3",
 	"textual",
 	"click>=8.1.7",
-	"textual-fspicker>=0.4.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,6 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "textual" },
-    { name = "textual-fspicker" },
 ]
 
 [package.dev-dependencies]
@@ -376,7 +375,6 @@ requires-dist = [
     { name = "httpx" },
     { name = "pydantic", specifier = "<3" },
     { name = "textual" },
-    { name = "textual-fspicker", specifier = ">=0.4.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -927,18 +925,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d3/ed0b20f6de0af1b7062c402d59d256029c0daa055ad9e04c27471b450cdd/textual_dev-1.7.0.tar.gz", hash = "sha256:bf1a50eaaff4cd6a863535dd53f06dbbd62617c371604f66f56de3908220ccd5", size = 25935, upload-time = "2024-11-18T16:59:47.924Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/4b/3c1eb9cbc39f2f28d27e10ef2fe42bfe0cf3c2f8445a454c124948d6169b/textual_dev-1.7.0-py3-none-any.whl", hash = "sha256:a93a846aeb6a06edb7808504d9c301565f7f4bf2e7046d56583ed755af356c8d", size = 27221, upload-time = "2024-11-18T16:59:46.833Z" },
-]
-
-[[package]]
-name = "textual-fspicker"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "textual" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/b0/5f895b15562064ef473bc1e882b6dfb1df4c29fd3259ba09aae481e289a6/textual_fspicker-0.4.1.tar.gz", hash = "sha256:94815262c12d38b69ccba85804d334b998f90ebda7c43d362e9665e59d72cb87", size = 356376, upload-time = "2025-02-28T10:12:05.511Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/17/6787a44e5516901f81ebd1ad65e28f8b46260a38be38b5136242b7ed08d7/textual_fspicker-0.4.1-py3-none-any.whl", hash = "sha256:c143f126c8664ba3bfe844d853d26caf0832c7d1b0f16d69e4a8654e8b2fb3d3", size = 21033, upload-time = "2025-02-28T10:12:03.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What's changing?

This adds a `flake.nix` file, allowing users to build and install LazyGithub via nix.

# Why is it changing?

Previous installation mechanisms meant either installing via the Github CLI or via `uvx`, which weren't always the most convenient.